### PR TITLE
fix import order

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -37,13 +37,11 @@ CommentPragmas:  '^ IWYU pragma:'
 ContinuationIndentWidth: 8
 DerivePointerAlignment: false
 DisableFormat:   false
-IncludeCategories: 
-  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
-    Priority:        2
-  - Regex:           '^(<|"(gtest|isl|json)/)'
-    Priority:        3
-  - Regex:           '.*'
-    Priority:        1
+IncludeCategories:
+  - Regex:  '^<'
+    Priority: -1
+  - Regex: '^"'
+    Priority: 1
 IndentCaseLabels: false
 IndentWidth:     8
 IndentWrappedFunctionNames: false

--- a/src/cfbf.c
+++ b/src/cfbf.c
@@ -1,7 +1,7 @@
-#include "cfbf.h"
 #include <getopt.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include "cfbf.h"
 
 // Version data
 #define VERSION_MAJOR '0'


### PR DESCRIPTION
I like when imports are ordered like this:
```
#include <stdio.h>
#include "something.h"
```
In this project standard lib imports come first and project imports come below.